### PR TITLE
Add UART busy flag and critical sections

### DIFF
--- a/Src/logger.c
+++ b/Src/logger.c
@@ -129,8 +129,8 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 #endif
         LOG_ENTER_CRITICAL();
         tx_busy = false;
-        LOG_EXIT_CRITICAL();
         ring_buffer_send_next();
+        LOG_EXIT_CRITICAL();
     }
 }
 


### PR DESCRIPTION
## Summary
- manage UART transmission state with new `tx_busy` flag
- guard ring buffer indices with critical sections

## Testing
- `gcc -c Src/logger.c -IInc` *(fails: unknown type name 'UART_HandleTypeDef')*

------
https://chatgpt.com/codex/tasks/task_e_687455d7768c8323abc7c146684b2491