### PR TITLE
Fix HAL UART callback docs

### DIFF
--- a/Docs/USAGE.md
+++ b/Docs/USAGE.md
@@ -74,12 +74,11 @@ You must define a UART handle externally:
 extern UART_HandleTypeDef huart1;
 ```
 
-And call the UART complete callback:
+Forward the UART TX complete interrupt to the logger:
 
 ```c
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
-    // Call into logger
-    Logger_HAL_UART_TxCpltCallback(huart); // or place `ring_buffer_send_next()` inline
+    Logger_UART_TxCpltCallback(huart); // provided by logger.c
 }
 ```
 

--- a/Inc/logger.h
+++ b/Inc/logger.h
@@ -102,3 +102,11 @@ __attribute__((weak)) void Log_Write_UART(const char* msg);
  * @param msg Null-terminated string to write to file.
  */
 __attribute__((weak)) void Log_Write_SD(const char* msg);
+
+/**
+ * @brief Handler for UART transmission complete events used by the logger.
+ *
+ * Call this from your own `HAL_UART_TxCpltCallback` if the application
+ * requires a custom implementation in addition to the logger's handling.
+ */
+void Logger_UART_TxCpltCallback(UART_HandleTypeDef *huart);

--- a/Src/logger.c
+++ b/Src/logger.c
@@ -88,11 +88,15 @@ static void ring_buffer_send_next(void) {
 }
 
 /**
- * @brief UART transmission complete callback handler.
- *        Should be called from HAL_UART_TxCpltCallback().
+ * @brief Handles completion of a UART transmission for the logger.
+ *
+ * This function contains the actual processing logic and can be called
+ * from a user-defined `HAL_UART_TxCpltCallback` if the application needs
+ * to handle the callback as well.
+ *
  * @param huart Pointer to the HAL UART handle.
  */
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
+void Logger_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
     if (huart->Instance == LOG_UART_HANDLE.Instance) {
 #if LOG_USE_DMA
         tail = (tail + huart->TxXferSize) % LOG_RING_BUFFER_SIZE;
@@ -101,6 +105,17 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 #endif
         ring_buffer_send_next();
     }
+}
+
+/**
+ * @brief HAL UART transmission complete callback.
+ *
+ * By default this simply forwards to `Logger_UART_TxCpltCallback()`. If the
+ * application defines its own `HAL_UART_TxCpltCallback`, it should call this
+ * function to keep the logger operating.
+ */
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
+    Logger_UART_TxCpltCallback(huart);
 }
 
 /**


### PR DESCRIPTION
## Summary
- document correct callback name for UART completion
- allow user code to forward interrupts by providing `Logger_UART_TxCpltCallback`

## Testing
- `gcc -c Src/logger.c -IInc` *(fails: unknown type `UART_HandleTypeDef`)*

------
https://chatgpt.com/codex/tasks/task_e_687455cb996483239223225ac2af5ab2